### PR TITLE
Fix: queries with variables passed not working with cache.

### DIFF
--- a/util/cache/middleware.go
+++ b/util/cache/middleware.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -42,9 +43,12 @@ func CachingMiddleware() func(http.Handler) http.Handler {
 			queryStr := strings.ReplaceAll(queryString, "\n", "")
 			queryStr = strings.ReplaceAll(queryStr, " ", "")
 
+			varBytes, _ := json.Marshal(body.Variables)
+			varString := string(varBytes)
+
 			// hash query
 			h := md5.New()
-			_, _ = io.WriteString(h, queryStr)
+			_, _ = io.WriteString(h, fmt.Sprint(queryStr, varString))
 			hash := hex.EncodeToString(h.Sum(nil))
 
 			respBodyBytes, err := GlobalCache.Get(r.Context(), hash)

--- a/util/cache/response.go
+++ b/util/cache/response.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -48,12 +49,15 @@ func RespMiddleware(next http.Handler) http.Handler {
 		queryStr := strings.ReplaceAll(queryString, "\n", "")
 		queryStr = strings.ReplaceAll(queryStr, " ", "")
 
+		varBytes, _ := json.Marshal(body.Variables)
+		varString := string(varBytes)
+
 		var data interface{}
 		saveBytes := crw.buf.Bytes()
 
 		_ = json.Unmarshal(saveBytes, &data)
 
-		err = SaveToCache(r.Context(), queryStr, data)
+		err = SaveToCache(r.Context(), fmt.Sprint(queryStr, varString), data)
 		if err != nil {
 			log.Println(err.Error())
 		}


### PR DESCRIPTION
Closes #82
- Consider query variables while calculating key for caching.
